### PR TITLE
(wip) adjust client-workload tests to allow throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "body-parser": "^1.13.3",
     "express": "^4.1.2",
     "fast-stats": "^0.0.3",
-    "metrics": "^0.1.9"
+    "metrics": "^0.1.9",
+    "sprintf-js": "^1.1.1"
   },
   "licenses": [
     {

--- a/src/client-workload.js
+++ b/src/client-workload.js
@@ -117,46 +117,57 @@ ClientWorkload.prototype._warmup = function (callback) {
 ClientWorkload.prototype._runWorkloadItems = function (callback) {
   this._logMessage('Running %d workload items');
   var options = this._commandLineOptions;
-  var self = this;
-  utils.eachSeries(this._items, function (item, next) {
-    var totalTimer;
-    console.log('---  %s / %s  ---', self._name, item.name);
-    if (self._commandLineOptions.measureLatency) {
+  utils.eachSeries(this._items, (item, next) => {
+    let totalTimer;
+    console.log('---  %s / %s  ---', this._name, item.name);
+    if (this._commandLineOptions.measureLatency) {
       totalTimer = new metrics.Timer();
     }
     utils.logTimerHeader();
-    var elapsed = [];
-    utils.timesSeries(options.series, function (n, nextIteration) {
-      var handler;
-      var seriesTimer;
-      var start;
-      if (self._commandLineOptions.measureLatency) {
-        seriesTimer = new metrics.Timer();
-        handler = function latencyTrackerHandler(n, timesNext) {
-          var queryStart = currentMicros();
-          item.fn(self._client, n, function (err) {
-            var duration = currentMicros() - queryStart;
-            seriesTimer.update(duration);
-            totalTimer.update(duration);
-            timesNext(err);
-          });
-        };
+    let handler;
+    let seriesTimer;
+    let intervalCount = 0;
+    if (this._commandLineOptions.measureLatency) {
+      seriesTimer = new metrics.Timer();
+      handler = (n, timesNext) => {
+        var queryStart = currentMicros();
+        item.fn(this._client, n, function (err) {
+          var duration = currentMicros() - queryStart;
+          seriesTimer.update(duration);
+          totalTimer.update(duration);
+          timesNext(err);
+        });
+      };
+    }
+    else {
+      handler = (n, timesNext) => {
+        item.fn(this._client, n, function (err) {
+          intervalCount++;
+          timesNext(err);
+        });
+      };
+    }
+
+    let lastTotalCount = 0;
+    let start = process.hrtime();
+    const onInterval = () => {
+      if (seriesTimer) {
+        intervalCount = seriesTimer.count() - lastTotalCount;
+        lastTotalCount = seriesTimer.count();
       }
-      else {
-        start = process.hrtime();
-        handler = function latencyTrackerHandler(n, timesNext) {
-          item.fn(self._client, n, timesNext);
-        };
-      }
-      utils.timesLimit(options.ops, options.outstanding, handler, function (err) {
-        elapsed.push(utils.logTimer(seriesTimer, null, start, options.ops));
-        nextIteration(err);
-      });
-    }, function (err) {
-      utils.logTotals(totalTimer, elapsed, options.ops * options.series);
+      utils.logTimer(seriesTimer, null, null, intervalCount);
+      intervalCount = 0; 
+    };
+
+    utils.timesPerSec(options.ops, options.outstanding, options.throttle, handler, onInterval, (err) => {
+      const elapsed = process.hrtime(start);
+      const millis = elapsed[0] * 1000 + elapsed[1] / 1000000;
+      utils.logTotals(totalTimer, millis, options.ops);
       next(err);
     });
-  }, callback);
+  }, (err) => {
+    callback(err);
+  });
 };
 
 module.exports = ClientWorkload;

--- a/test/workload-standard-test-simulacron.js
+++ b/test/workload-standard-test-simulacron.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var ClientWorkload = require('../src/client-workload');
+
+var insertQuery = "INSERT INTO standard1 (key, c0, c1, c2, c3, c4) VALUES (?, ?, ?, ?, ?, ?)";
+var selectQuery = "SELECT key, c0, c1, c2, c3, c4 FROM standard1 WHERE key = ?";
+
+var workload = new ClientWorkload('Standard1');
+workload
+  .queries([
+    "DROP KEYSPACE IF EXISTS test_nodejs_benchmarks_standard",
+    "CREATE KEYSPACE test_nodejs_benchmarks_standard WITH replication = {'class': 'SimpleStrategy'," +
+    " 'replication_factor' : 1} and durable_writes = true",
+    "USE test_nodejs_benchmarks_standard",
+    "CREATE TABLE standard1 (key text PRIMARY KEY,c0 text,c1 text,c2 text,c3 text,c4 text)"
+  ])
+  .add('insert', function (client, n, callback) {
+    var b = n + '';
+    client.execute(insertQuery, [ b, b, b, b, b, b], { prepare: true }, callback);
+  })
+  .add('select', function (client, n, callback) {
+    var b = n + '';
+    client.execute(selectQuery, [ b ], { prepare: true }, callback);
+  })
+  .run();


### PR DESCRIPTION
This is currently a bit messy, but update client workload tests to allow throttling at a rate per second.

My hope is this might make it easier to profile things, as it ensures that work is done at the same rate as long as its able to keep up, as opposed to when running at full throughput where it can make things harder to compare if one trial is doing more at once than another.

In addition, it will be nice to compare latencies at target throughputs between versions.